### PR TITLE
Quotas guidance is added to Ingest API page

### DIFF
--- a/doc_source/ingest-api.md
+++ b/doc_source/ingest-api.md
@@ -5,9 +5,9 @@ You can use the AWS IoT SiteWise API to send timestamped industrial data to your
 Use the [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) operation to upload your data\. With this operation, you can upload multiple data entries at a time, so that you can collect data from several devices and send it all in a single request\.
 
 **Important**  
-The [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) operation is subject to following quotas:
--  You can specify up to 10 [entries](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html#API_BatchPutAssetPropertyValue_RequestSyntax) per request\. 
--  You can specify up to 10 [propertyValues](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_PutAssetPropertyValueEntry.html#iotsitewise-Type-PutAssetPropertyValueEntry-propertyValues) (TQV data points) per entry\. 
+The [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) operation is subject to the following quotas:
+- Up to 10 [entries](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html#API_BatchPutAssetPropertyValue_RequestSyntax) per request\.
+- Up to 10 [propertyValues](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_PutAssetPropertyValueEntry.html#iotsitewise-Type-PutAssetPropertyValueEntry-propertyValues) (TQV data points) per entry\.
 -  AWS IoT SiteWise rejects any data with a timestamp dated to more than 7 days in the past or more than 10 minutes in the future\. 
 
 For more information about these quotas, see [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) in the *AWS IoT SiteWise API Reference*\.

--- a/doc_source/ingest-api.md
+++ b/doc_source/ingest-api.md
@@ -5,7 +5,12 @@ You can use the AWS IoT SiteWise API to send timestamped industrial data to your
 Use the [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) operation to upload your data\. With this operation, you can upload multiple data entries at a time, so that you can collect data from several devices and send it all in a single request\.
 
 **Important**  
-The [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) operation is subject to quotas on the number of entries per request and the number of TQV data points per entry\. AWS IoT SiteWise also rejects any data with a timestamp dated to more than 7 days in the past or more than 10 minutes in the future\. For more information about these quotas, see [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) in the *AWS IoT SiteWise API Reference*\.
+The [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) operation is subject to following quotas:
+-  You can specify up to 10 [entries](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html#API_BatchPutAssetPropertyValue_RequestSyntax) per request\. 
+-  You can specify up to 10 [propertyValues](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_PutAssetPropertyValueEntry.html#iotsitewise-Type-PutAssetPropertyValueEntry-propertyValues) (TQV data points) per entry\. 
+-  AWS IoT SiteWise rejects any data with a timestamp dated to more than 7 days in the past or more than 10 minutes in the future\. 
+
+For more information about these quotas, see [BatchPutAssetPropertyValue](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchPutAssetPropertyValue.html) in the *AWS IoT SiteWise API Reference*\.
 
 To identify an asset property, you can specify one of the following:
 + The `assetId` and `propertyId` of the asset property that you are sending data to\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Quotas of BatchPutAssetPropertyValue API on the [Ingesting data using the AWS IoT SiteWise API](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/ingest-api.html) isn't clear at the first glance. Also, one customer missed the point that they are able to ingest 10 entries * 10 propertyValues = 100 TQV in total. It's better to have this guidance on the Ingest API page firstly, in addition to the API request parameter detail pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
